### PR TITLE
Update swipe_to.dart

### DIFF
--- a/lib/src/swipe_to.dart
+++ b/lib/src/swipe_to.dart
@@ -163,17 +163,24 @@ class _SwipeToState extends State<SwipeTo> with SingleTickerProviderStateMixin {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onPanUpdate: (details) {
-        if (details.delta.dx > widget.swipeSensitivity &&
-            widget.onRightSwipe != null) {
-          _runAnimation(onRight: true, details: details);
-        }
-        if (details.delta.dx < -(widget.swipeSensitivity) &&
-            widget.onLeftSwipe != null) {
-          _runAnimation(onRight: false, details: details);
-        }
-      },
+    // Changed by @AnkitFlutterDev
+    return RawGestureDetector(
+     gestures: <Type, GestureRecognizerFactory>{
+      HorizontalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<HorizontalDragGestureRecognizer>(
+        () => HorizontalDragGestureRecognizer(debugOwner: this),
+        (HorizontalDragGestureRecognizer instance) {
+          instance
+            ..onUpdate = (details) {
+              if (details.delta.dx > widget.swipeSensitivity && widget.onRightSwipe != null) {
+                _runAnimation(onRight: true, details: details);
+              } else if (details.delta.dx < -widget.swipeSensitivity && widget.onLeftSwipe != null) {
+                _runAnimation(onRight: false, details: details);
+              }
+            };
+        },
+      ),
+    },
+    behavior: HitTestBehavior.translucent,
       child: Stack(
         alignment: Alignment.center,
         fit: StackFit.passthrough,


### PR DESCRIPTION
Fixed the issue of https://github.com/Purvik/SwipeTo/issues/28


✅ Why This Works
•	RawGestureDetector gives us fine-grained control over gesture recognition. 
•	It avoids blocking vertical scrolls while still detecting deliberate horizontal drags. 
•	Flutter’s gesture arena can now disambiguate vertical vs. horizontal gestures correctly.